### PR TITLE
Set new document language to "CSV (pipe)"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,7 +68,8 @@ function registerCsvToTableCommand(separator: string, commandName: string): vsco
 			if (settings.openGeneratedTableInNewEditor) {
 				// Open new window
 				const newDoc = await vscode.workspace.openTextDocument({
-					content: formattedResult
+					content: formattedResult,
+					language: 'csv (pipe)'
 				});
 				vscode.window.showTextDocument(newDoc, vscode.ViewColumn.Active);
 			} else {


### PR DESCRIPTION
This PR automatically sets the new document language to "CSV (pipe)".

The purpose of this is when you have the "Markdown Format" setting is enabled, the output is not automatically detected as a "CSV (pipe)" but just "plain text".

![image](https://github.com/Plasma/csv-to-table/assets/484912/eb2c1217-4d9b-4224-8fcc-3444d67c3784)

<img width="602" alt="image" src="https://github.com/Plasma/csv-to-table/assets/484912/daf53c1d-95e1-41bd-a730-07f3c346702d">

This is not technically a problem but I also use an extension called [Rainbow CSV](https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv) which does nice color highlighting of the CSV columns. But this only happens for a document with piped CSV if the document language is set to "CSV (pipe)".

(Technically the Rainbow CSV extension has a "table align" feature but it keeps the existing separator which doesn't look as good)

After setting the document to "CSV (pipe)" then the highlighting works

<img width="770" alt="image" src="https://github.com/Plasma/csv-to-table/assets/484912/8dd47ee9-b248-4b96-83a1-2313c3e89de9">
